### PR TITLE
chore(script.js): moved ts-expect error to proper line

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ export async function script(octokit, repository, options) {
     return;
   }
 
+  // @ts-expect-error expects { sha } to be present when status 404 (see #6)
   const { pkg, sha } = await octokit
     .request("GET /repos/{owner}/{repo}/contents/{path}", {
       owner,
@@ -51,8 +52,7 @@ export async function script(octokit, repository, options) {
         }
       },
       (error) => {
-        // @ts-expect-error expects { sha} to be present (see #6)
-        if (error.status === 404) return { pkg: false, sha: undefined };
+        if (error.status === 404) return { pkg: false };
         throw error;
       }
     );


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Move `@ts-expecte-error` to proper line.

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The previous line where it was placed it was not taking any effect:
![image](https://user-images.githubusercontent.com/2574275/110256372-e2b1ed00-7f98-11eb-97b9-1a1f69f71985.png)

With this change, we make sure when a TS version fixes this issue, the comment will be highlighted and ready to be removed.